### PR TITLE
Add preferences and dialog to edit them

### DIFF
--- a/gg_menubar.py
+++ b/gg_menubar.py
@@ -14,8 +14,8 @@ class GGmenubar(tk.Menu):
 
         self.initFileMenu(root)
         self.initEditMenu(root)
-        self.initHelpMenu(root)
         self.initViewMenu(root)
+        self.initHelpMenu(root)
         self.initOSMenu(root)
 
     def initFileMenu(self, root):
@@ -34,6 +34,8 @@ class GGmenubar(tk.Menu):
         menu_edit.addCutCopyPaste()
         menu_edit.add_separator()
         menu_edit.addButton("Select ~All", "<<SelectAll>>", "Cmd/Ctrl+A")
+        menu_edit.add_separator()
+        menu_edit.addButton("Pre~ferences...", root.showMyPreferencesDialog)
 
     def initViewMenu(self, root):
         menu_view = GGmenu(self, "~View")

--- a/gg_prefs.py
+++ b/gg_prefs.py
@@ -1,0 +1,74 @@
+# Singleton class to handle setting/getting/saving/loading/defaulting preferences
+
+import json
+import os
+import tkinter as tk
+
+from gg_tkutils import isX11
+
+
+class GGprefs:
+    _self = None
+
+    def __new__(cls):
+        if cls._self is None:
+            cls._self = super().__new__(cls)
+            cls._self.initialize()
+        return cls._self
+
+    #
+    # Initialize prefs by loading from file
+    def initialize(self):
+        self.dict = {}
+        self.defaults = {}
+        if isX11():
+            self.prefsdir = os.path.join(os.path.expanduser("~"), ".GGprefs")
+        else:
+            self.prefsdir = os.path.join(
+                os.path.expanduser("~"), "Documents", "GGprefs"
+            )
+        self.prefsfile = os.path.join(self.prefsdir, "GGprefs.json")
+        self.load()
+
+    #
+    # Set default prefs value using key
+    # Default is returned if `get` fails to find key in dictionary
+    def setDefault(self, key, default):
+        self.defaults[key] = default
+
+    #
+    # Get default prefs value using key
+    # None is returned if no default is set
+    def getDefault(self, key):
+        return self.defaults.get(key)
+
+    #
+    # Set prefs value using key
+    # For now, always save when new value set
+    def set(self, key, value):
+        self.dict[key] = value
+        self.save()
+
+    #
+    # Get prefs value; default if key not found; None if no default
+    def get(self, key):
+        return self.dict.get(key, self.getDefault(key))
+
+    #
+    # Get list of prefs keys
+    def keys(self):
+        return self.dict.keys()
+
+    # Save prefs dictionary to JSON file
+    def save(self):
+        key = "mykey"
+        if not os.path.isdir(self.prefsdir):
+            os.mkdir(self.prefsdir)
+        with open(self.prefsfile, "w") as fp:
+            json.dump(self.dict, fp, indent=2)
+
+    # Load prefs dictionary from JSON file
+    def load(self):
+        if os.path.isfile(self.prefsfile):
+            with open(self.prefsfile, "r") as fp:
+                self.dict = json.load(fp)

--- a/gg_prefsdialog.py
+++ b/gg_prefsdialog.py
@@ -1,0 +1,46 @@
+# GGprefsdialog class is a ttk simple dialog
+
+import tkinter as tk
+from tkinter import simpledialog
+
+from gg_prefs import GGprefs
+
+
+class GGprefsdialog(tk.simpledialog.Dialog):
+    def __init__(self, parent, title):
+        self.labels = {}
+        self.entries = {}
+        super().__init__(parent, title)
+
+    # Show all prefs keys/values
+    def body(self, frame):
+        # Does not cope with non-string values,
+        # since converted to string for display in dialog
+        for row, key in enumerate(GGprefs().keys()):
+            self.labels[key] = tk.Label(frame, text=key)
+            self.labels[key].grid(row=row, column=0)
+            self.entries[key] = tk.Entry(frame, width=12)
+            self.entries[key].insert(tk.END, str(GGprefs().get(key)))
+            self.entries[key].grid(row=row, column=1)
+        return frame
+
+    def ok_pressed(self):
+        # Does not cope with non-string values,
+        # since get() always return string
+        for key in GGprefs().keys():
+            GGprefs().set(key, self.entries[key].get())
+        GGprefs().save()
+        self.destroy()
+
+    def cancel_pressed(self):
+        self.destroy()
+
+    def buttonbox(self):
+        self.ok_button = tk.Button(self, text="OK", width=5, command=self.ok_pressed)
+        self.ok_button.pack(side="left")
+        cancel_button = tk.Button(
+            self, text="Cancel", width=5, command=self.cancel_pressed
+        )
+        cancel_button.pack(side="right")
+        self.bind("<Return>", lambda event: self.ok_pressed())
+        self.bind("<Escape>", lambda event: self.cancel_pressed())

--- a/gg_tkutils.py
+++ b/gg_tkutils.py
@@ -2,6 +2,8 @@
 #
 # Attempt to avoid passing root & maintext widgets everywhere for the
 # few places they are needed - to be reviewed/reconsidered
+# Maybe use singleton classes for root, maintext, mainimage
+# - only appropriate if certain there will only be one instance
 
 import re
 import tkinter as tk

--- a/guiguts.py
+++ b/guiguts.py
@@ -10,6 +10,8 @@ import webbrowser
 from gg_mainimage import GGmainimage
 from gg_maintext import GGmaintext
 from gg_menubar import GGmenubar
+from gg_prefs import GGprefs
+from gg_prefsdialog import GGprefsdialog
 from gg_tkutils import isMac, ggRoot, ggMainText, ggMainImage
 
 
@@ -22,6 +24,8 @@ class Guiguts(tk.Tk):
         self.option_add("*tearOff", False)
         self.rowconfigure(0, weight=1)
         self.columnconfigure(0, weight=1)
+
+        self.setPrefsDefaults()
 
         frame = ttk.Frame(self, padding="5 5 5 5")
         frame.grid(column=0, row=0, sticky="NSEW")
@@ -45,8 +49,12 @@ class Guiguts(tk.Tk):
         frame.rowconfigure(0, weight=1)
         frame.columnconfigure(0, weight=1)
         ggMainText().grid(column=0, row=0, sticky="NSEW")
+
         frame.columnconfigure(1, weight=0)
-        ggMainImage().grid(column=1, row=0, sticky="NSEW")
+        if GGprefs().get("ImageWindow") == "Docked":
+            self.dockImage()
+        else:
+            self.floatImage()
 
         if isMac():
             self.createcommand("tk::mac::ShowPreferences", self.showMyPreferencesDialog)
@@ -110,9 +118,7 @@ class Guiguts(tk.Tk):
         )
 
     def showMyPreferencesDialog(self, *args):
-        messagebox.showwarning(
-            title="Preferences", message="Prefs dialog hasn't been written yet"
-        )
+        GGprefsdialog(self, "Set Preferences")
 
     # Handle drag/drop on Macs
     def openDocument(self, args):
@@ -127,18 +133,23 @@ class Guiguts(tk.Tk):
     def floatImage(self, *args):
         self.wm_manage(ggMainImage())
         ggMainImage().lift()
-        tk.Wm.protocol(
-            ggMainImage(), "WM_DELETE_WINDOW", self.dockImage
-        )  # re-dock if window closed
+        tk.Wm.protocol(ggMainImage(), "WM_DELETE_WINDOW", self.dockImage)
+        GGprefs().set("ImageWindow", "Floated")
 
     def dockImage(self, *args):
         self.wm_forget(ggMainImage())
         ggMainImage().grid(column=1, row=0, sticky="NSEW")
+        GGprefs().set("ImageWindow", "Docked")
 
     def loadImage(self, *args):
         filename = ggMainText().getImageFilename()
         ggMainImage().loadImage(filename)
         ggMainImage().lift()
+
+    #
+    # Set default preference values - will be overridden by any values set in the GGprefs file
+    def setPrefsDefaults(self):
+        GGprefs().setDefault("ImageWindow", "Docked")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Only current preference used in program is whether image dialog is "Docked" or "Floated" - key is "ImageWindow"

Prefs are stored in the normal Guiguts GGprefs directory (`HomeDir/Documents/GGprefs` on Windows/Mac, or
`HomeDir/.GGprefs` on Linux). Filename is `GGprefs.json`

Could manually add another "preference" by editing `GGprefs.json` but of course program will do nothing with it, apart from loading it and saving it again. E.g. add line to `GGprefs.json`, `  "Favorite Color": "red"`

The docked/floated status of the image window should now be persistent across runs of the program. Prefs are loaded when program starts - anything not set in the prefs file will default to a value set in the program ("ImageWindow" defaults to "Docked")

To test dialogs, use Edit->Preferences to edit all the currently loaded preferences. Click OK to save any edits. Not intended as a serious way to edit prefs, just a test of dialogs and loading/saving prefs.