### PR TITLE
Add option to test spawning a tool

### DIFF
--- a/child.py
+++ b/child.py
@@ -1,0 +1,8 @@
+# Child process
+import sys
+
+input_string = input()
+print(f'Received "{input_string}"')
+output_string = input_string.upper()
+print(f'Output "{output_string}"')
+print("This should appear in stderr", file=sys.stderr)

--- a/gg_menubar.py
+++ b/gg_menubar.py
@@ -24,6 +24,8 @@ class GGmenubar(tk.Menu):
         menu_file.addButton("~Save", root.saveFile, "Cmd/Ctrl+S")
         menu_file.addButton("Save ~As...", root.saveasFile, "Cmd/Ctrl+Shift+S")
         menu_file.add_separator()
+        menu_file.addButton("Spawn ~Process", root.spawnProcess)
+        menu_file.add_separator()
         menu_file.addButton("~Quit", root.quitProgram, "Cmd+Q" if isMac() else "")
 
     def initEditMenu(self, root):

--- a/guiguts.py
+++ b/guiguts.py
@@ -3,6 +3,7 @@
 
 import os.path
 import re
+import subprocess
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 import webbrowser
@@ -145,6 +146,17 @@ class Guiguts(tk.Tk):
         filename = ggMainText().getImageFilename()
         ggMainImage().loadImage(filename)
         ggMainImage().lift()
+
+    # Handle spawning a process
+    def spawnProcess(self, *args):
+        result = subprocess.run(
+            "python child.py",
+            input="Convert me to uppercase",
+            text=True,
+            capture_output=True,
+        )
+        messagebox.showinfo(title="Spawn stdout", message=result.stdout)
+        messagebox.showinfo(title="Spawn stderr", message=result.stderr)
 
     #
     # Set default preference values - will be overridden by any values set in the GGprefs file


### PR DESCRIPTION
In File menu, Spawn Process runs `child.py` as a subprocess, and sends it some text as input.
This script accepts the standard input, echoes what it receives, then uppercases it and echoes that. It also outputs a message to stderr.