### PR TITLE
Separate out File operations

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,3 +26,8 @@ Utilities
 =========
     
 .. automodule:: utilities
+ 
+File
+=========
+    
+.. automodule:: file

--- a/src/file.py
+++ b/src/file.py
@@ -1,0 +1,92 @@
+"""Handle file operations"""
+
+import os.path
+from tkinter import filedialog, messagebox
+
+from mainwindow import maintext
+
+
+class File:
+    """Handle data and actions relating to the main text file"""
+
+    def __init__(self, filename_callback):
+        """
+        Args:
+            filename_callback: function to be called whenever filename is set.
+        """
+        self._filename = ""
+        self._filename_callback = filename_callback
+
+    @property
+    def filename(self):
+        """Name of currently loaded file
+
+        When assigned to, executes callback function to update interface"""
+        return self._filename
+
+    @filename.setter
+    def filename(self, value):
+        self._filename = value
+        self._filename_callback()
+
+    def open_file(self, *args):
+        """Open and load a text file."""
+        if self.check_save():
+            fn = filedialog.askopenfilename(
+                filetypes=(("Text files", "*.txt *.html *.htm"), ("All files", "*.*"))
+            )
+            if fn:
+                self.filename = fn
+                maintext().do_open(self.filename)
+
+    def save_file(self, *args):
+        """Save the current file.
+
+        Returns:
+            Current filename or None if save is cancelled
+        """
+        if self.filename:
+            maintext().do_save(self.filename)
+            return self.filename
+        else:
+            return self.save_as_file()
+
+    def save_as_file(self, *args):
+        """Save current text as new file.
+
+        Returns:
+            Chosen filename or None if save is cancelled
+        """
+        fn = filedialog.asksaveasfilename(
+            initialfile=os.path.basename(self.filename),
+            initialdir=os.path.dirname(self.filename),
+            filetypes=[("All files", "*")],
+        )
+        if fn:
+            self.filename = fn
+            maintext().do_save(self.filename)
+        return fn
+
+    def check_save(self):
+        """If file has been edited, check if user wants to save,
+        or discard, or cancel the intended operation.
+
+        Returns:
+            True if OK to continue with intended operation.
+        """
+        if not maintext().is_modified():
+            return True
+
+        save = messagebox.askyesnocancel(
+            title="Save document?",
+            message="Save changes to document first?",
+            detail="Your changes will be lost if you don't save them.",
+            icon=messagebox.WARNING,
+        )
+        # Trap Cancel from messagebox
+        if save is None:
+            return False
+        # Trap Cancel from save-as dialog
+        if save and not self.save_file():
+            return False
+        return True

--- a/src/mainwindow.py
+++ b/src/mainwindow.py
@@ -226,8 +226,16 @@ class MainText(tk.Text):
         """
         lk = re.sub("[A-Z]>$", lambda m: m.group(0).lower(), keyevent)
         uk = re.sub("[A-Z]>$", lambda m: m.group(0).upper(), keyevent)
-        self.bind(lk, handler)
-        self.bind(uk, handler)
+
+        def handler_break(event, func):
+            """In order for class binding not to be called after widget
+            binding, event handler for widget needs to return "break"
+            """
+            func(event)
+            return "break"
+
+        self.bind(lk, lambda event: handler_break(event, handler))
+        self.bind(uk, lambda event: handler_break(event, handler))
 
     #
     # Handle "modified" flag

--- a/src/preferences_dialog.py
+++ b/src/preferences_dialog.py
@@ -1,11 +1,12 @@
 """Dialog to handle preferences"""
 
 import tkinter as tk
+from tkinter import simpledialog
 
 from preferences import preferences
 
 
-class PreferencesDialog(tk.simpledialog.Dialog):
+class PreferencesDialog(simpledialog.Dialog):
     """A Tk simpledialog that allows the user to view/edit all preferences.
 
     Attributes:


### PR DESCRIPTION
1. Separate out File operations into their own module
2. Also fix key binding bug - by default Ctrl-O adds a blank line to a Text widget. We have bound it to Open File in our Text widget, but the class binding was still being called, so doing Open File also added a blank line (at the end of the file) so the file appeared "edited" immediately after loading. By returning the string "break" from the instance callback, it stops the class callback being called.