### PR TITLE
Make png load work better

### DIFF
--- a/src/file.py
+++ b/src/file.py
@@ -53,6 +53,7 @@ class File:
         """
         self.filename = filename
         maintext().do_open(filename)
+        maintext().set_insert_index(1.0, see=True)
         self.load_bin(filename)
         if not self.contains_page_marks():
             self.mark_page_boundaries()
@@ -240,7 +241,7 @@ class File:
         return False
 
     def get_current_image_name(self):
-        """Find name of the image file corresponding to where the
+        """Find basename of the image file corresponding to where the
         insert cursor is.
 
         Returns:
@@ -252,6 +253,21 @@ class File:
             if is_page_mark(mark):
                 return img_from_page_mark(mark)
         return ""
+
+    def get_current_image_path(self):
+        """Return the path of the image file for the page where the insert
+        cursor is located.
+
+        Returns:
+            Name of the image file for the current page, or the empty string
+            if unable to get image file name.
+        """
+        basename = self.get_current_image_name()
+        if basename:
+            basename += ".png"
+            return os.path.join(os.path.dirname(self.filename), "pngs", basename)
+        else:
+            return ""
 
 
 def is_page_mark(mark):

--- a/src/guiguts.py
+++ b/src/guiguts.py
@@ -82,7 +82,7 @@ class Guiguts:
 
     def load_image(self, *args):
         """Load the image for the current page."""
-        filename = maintext().get_image_filename()
+        filename = self.file.get_current_image_path()
         mainimage().load_image(filename)
         if preferences.get("ImageWindow") == "Docked":
             mainimage().dock_image()

--- a/src/mainwindow.py
+++ b/src/mainwindow.py
@@ -306,22 +306,6 @@ class MainText(tk.Text):
         else:
             self.bind("<3>", post_context_menu)
 
-    def get_image_filename(self):
-        """Return the name of the image file for the page where the insert
-        cursor is located.
-
-        Returns:
-            Name of the image file for the current page, or the empty string
-            if unable to get image file name.
-        """
-        sep_index = self.search(
-            "//-----File: ", self.get_insert_index(), backwards=True
-        )
-        if sep_index:
-            return self.get(sep_index + "+13c", sep_index + "lineend").rstrip("-")
-        else:
-            return ""
-
     def get_insert_index(self):
         """Return index of the insert cursor."""
         return self.index(tk.INSERT)


### PR DESCRIPTION
Assume pngs are in `pngs` subfolder below text file location.

Also, minor bug fix: set cursor to start of file when loaded - will be overridden by "current" location when last saved if there is a bin file.