### PR TITLE
Add macOS dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,17 @@
 
 Guiguts rewrite using Python/tkinter
  
- 
-## Windows-focused dev installation
+## Windows Development Setup
 
 Minor alterations probably needed for other platforms
 
-## Install Python
+### Install Python
 
-    1. Download 3.10 from python.org
-    2. Install – default dir is `C:\Users\<username>\AppData\Local\Programs\Python\Python310`
-    3. Ensure this dir is in PATH variable
+1. Download 3.10 from [python.org](https://www.python.org/).
+2. Install – default dir is `C:\Users\<username>\AppData\Local\Programs\Python\Python310`
+3. Ensure this dir is in PATH variable
 
-## Install Poetry
+### Install Poetry
 
 1. https://python-poetry.org/docs/#installing-with-the-official-installer 
 2. `(Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | py -`
@@ -21,13 +20,49 @@ Minor alterations probably needed for other platforms
 4. Adds top-level “poetry” wrapper in `C:\Users\<username>\AppData\Roaming\Python\Scripts`
 5. Ensure the latter is in PATH variable
 
-## Set up Development System
+## macOS Development Setup
+
+Developing Guiguts on macOS requires installing [Homebrew](https://brew.sh/) first.
+
+### Install Python
+
+Install python and python-tk using Homebrew. Note that we install and use a
+specific version in the commands below for consistency with other developers.
+
+```bash
+brew install python@3.10 python-tk@3.10
+```
+
+### Install Poetry
+
+We also install poetry using Homebrew.
+
+```bash
+brew install poetry
+```
+
+## Common Development Setup
 
 1. Install Python & Poetry (above)
 2. Clone the [GG2 Github repo](https://github.com/windymilla/Guiguts-2.0-tkinter)
-3. In the cloned GG2 directory, `poetry install`. The message
-   ".../guiguts does not contain any element" can be ignored (or suppressed by using
-   `poetry install --no-root` instead).
+   or a fork thereof.
+3. In the cloned GG2 directory, create a virtual environment using the version of
+   python you installed above.
+   * Windows
+     ```
+     poetry env use C:\Users\<username>\AppData\Local\Programs\Python\Python310\python3
+     ```
+   * macOS
+     ```bash
+     poetry env use /usr/local/bin/python3.10
+     ```
+4. Also from the GG2 directory, install the GG2 python dependencies in the
+   virtual environment.
+   ```bash
+   poetry install --no-root
+   ```
+
+You can access the virtual environment shell with `poetry shell`.
 
 ## Code style
 Guiguts 2 uses [flake8](https://pypi.org/project/flake8) for static code analysis

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ brew install poetry
    or a fork thereof.
 3. In the cloned GG2 directory, create a virtual environment using the version of
    python you installed above.
-   * Windows
-     ```
-     poetry env use C:\Users\<username>\AppData\Local\Programs\Python\Python310\python3
+   * Windows (in git bash shell)
+     ```bash
+     poetry env use ~/AppData/Local/Programs/Python/Python310/python.exe
      ```
    * macOS
      ```bash


### PR DESCRIPTION
This adds dev instructions for macOS and some slight restructuring to accommodate two platforms plus some common bits.

I'm guessing at the `poetry use` incantation for Windows -- it should point to the python binary. Without this poetry will use the first version of python on the path. For Windows this might not be a problem, but for macOS it is as macOS comes with a version and multiple can be installed concurrently from Homebrew. To keep the instructions parallel I added the Windows example but we can leave that out if it's too confusing.