### PR TITLE
Provide get/setitem methods for preferences

### DIFF
--- a/src/guiguts.py
+++ b/src/guiguts.py
@@ -84,7 +84,7 @@ class Guiguts:
         """Load the image for the current page."""
         filename = self.file.get_current_image_path()
         mainimage().load_image(filename)
-        if preferences.get("ImageWindow") == "Docked":
+        if preferences["ImageWindow"] == "Docked":
             self.mainwindow.dock_image()
         else:
             self.mainwindow.float_image()

--- a/src/mainwindow.py
+++ b/src/mainwindow.py
@@ -104,7 +104,7 @@ class MainWindow:
             tk.Wm.protocol(mainimage(), "WM_DELETE_WINDOW", self.dock_image)
         else:
             root().wm_forget(mainimage())
-        preferences.set("ImageWindow", "Floated")
+        preferences["ImageWindow"] = "Floated"
 
     def dock_image(self, *args):
         """Dock the image back into the main window"""
@@ -116,7 +116,7 @@ class MainWindow:
                 self.paned_window.forget(mainimage())
             except tk.TclError:
                 pass  # OK - image wasn't being managed by paned_window
-        preferences.set("ImageWindow", "Docked")
+        preferences["ImageWindow"] = "Docked"
 
 
 class Menu(tk.Menu):
@@ -654,7 +654,7 @@ def sound_bell():
     Visible flashes the first statusbar button (must be ttk.Button)
     Preference "Bell" contains "Audible", "Visible", both or neither
     """
-    bell_pref = preferences.get("Bell")
+    bell_pref = preferences["Bell"]
     if "Audible" in bell_pref:
         root().bell()
     if "Visible" in bell_pref:

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -31,6 +31,32 @@ class Preferences:
         self._remove_test_prefs_file()
         self.load()
 
+    def __getitem__(self, key):
+        """Get preference value using key.
+
+        Provides `value = preferences[key]`
+
+        Args:
+            key: Name of preference.
+
+        Returns:
+            Preferences value; default for ``key`` if no preference set;
+            ``None`` if no default for ``key``.
+        """
+        return self.dict.get(key, self.get_default(key))
+
+    def __setitem__(self, key, value):
+        """Set preference value and save to file.
+
+        Provides `preferences[key] = value`
+
+        Args:
+            key: Name of preference.
+            value: Value for preference.
+        """
+        self.dict[key] = value
+        self.save()
+
     def __del__(self):
         """Remove any test prefs file when finished."""
         self._remove_test_prefs_file()
@@ -54,28 +80,6 @@ class Preferences:
             Default value for preference; ``None`` if no default for ``key``
         """
         return self.defaults.get(key)
-
-    def set(self, key, value):
-        """Set preference value and save to file.
-
-        Args:
-            key: Name of preference.
-            value: Value for preference.
-        """
-        self.dict[key] = value
-        self.save()
-
-    def get(self, key):
-        """Get preference value using key.
-
-        Args:
-            key: Name of preference.
-
-        Returns:
-            Preferences value; default for ``key`` if no preference set;
-            ``None`` if no default for ``key``.
-        """
-        return self.dict.get(key, self.get_default(key))
 
     def keys(self):
         """Return list of preferences keys.

--- a/src/preferences_dialog.py
+++ b/src/preferences_dialog.py
@@ -35,7 +35,7 @@ class PreferencesDialog(simpledialog.Dialog):
             self.labels[key] = ttk.Label(frame, text=key)
             self.labels[key].grid(row=row, column=0)
             self.entries[key] = ttk.Entry(frame, width=20)
-            self.entries[key].insert(tk.END, str(preferences.get(key)))
+            self.entries[key].insert(tk.END, str(preferences[key]))
             self.entries[key].grid(row=row, column=1)
         return frame
 
@@ -61,7 +61,7 @@ class PreferencesDialog(simpledialog.Dialog):
         always returns a string.
         """
         for key in preferences.keys():
-            preferences.set(key, self.entries[key].get())
+            preferences[key] = self.entries[key].get()
         preferences.save()
         self.destroy()
 

--- a/tests/test_guiguts.py
+++ b/tests/test_guiguts.py
@@ -24,12 +24,17 @@ def test_preferences():
     assert preferences.get_default("pkey1") is None
     preferences.set_default("pkey1", "pdefault1")
     assert preferences.get_default("pkey1") == "pdefault1"
-    preferences.set("pkey1", "pvalue1")
-    assert preferences.get("pkey1") == "pvalue1"
+    preferences["pkey1"] = "pvalue1"
+    assert preferences["pkey1"] == "pvalue1"
     assert preferences.get_default("pkey1") == "pdefault1"
     keys = preferences.keys()
     assert len(keys) == 1
     assert "pkey1" in keys
+    preferences.set_default("pkey2", "pdefault2")
+    keys = preferences.keys()
+    assert len(keys) == 2
+    assert "pkey1" in keys
+    assert "pkey2" in keys
 
 
 def test_mainwindow():


### PR DESCRIPTION
To simplify use of preferences, allow
`preferences["key"] = "values"`, instead of requiring call to `set` method.