### PR TITLE
Use dynamic homebrew path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ brew install poetry
      ```
    * macOS
      ```bash
-     poetry env use /usr/local/bin/python3.10
+     poetry env use $(brew --prefix)/bin/python3.10
      ```
 4. Also from the GG2 directory, install the GG2 python dependencies in the
    virtual environment. This will install GG2 as an editable package that you


### PR DESCRIPTION
The install directory for Homebrew varies on Intel and Apple Silicon systems. This command works for either.

Technically, it's possible to install Homebrew in any path. So this approach would also find Homebrew if installed in a custom path that is not the normal platform default.